### PR TITLE
Add mutually exclusive feature check

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,10 @@ use crate::{
     },
 };
 
+// ring and aws_lc_rs are mutually exclusive.
+#[cfg(all(feature = "aws_lc_rs", feature = "ring"))]
+compile_error!("features `aws_lc_rs` and `ring` cannot be enabled at the same time");
+
 #[cfg(feature = "aws_lc_rs")]
 pub use rustls::crypto::aws_lc_rs as crypto_provider;
 #[cfg(feature = "ring")]


### PR DESCRIPTION
Hello,

This PR completes PR #6. It adds a small safeguard for the crypto features. The project exposes two providers (aws_lc_rs and ring) that cannot be enabled at the same time, and this only became visible once the CI was in place. I’ve added a compile-time check to make the constraint explicit and to prevent invalid feature combinations.