### PR TITLE
feat(config): add auto lowercase for domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "ttl_cache",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ regex = "1"
 
 toml = "1"
 
+url = "2"
+
 [dev-dependencies]
 axum-test = "21"
 httpmock = "0.8"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,8 +8,8 @@ fn deserialize_lowercase<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let value = String::deserialize(deserializer)?;
-    Ok(value.to_lowercase())
+    let value: String = String::deserialize(deserializer)?;
+    Ok(value.to_ascii_lowercase())
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,36 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+// Lowercase at import time the requested string.
+// This will enforce domains to be lowercase...
+fn deserialize_lowercase<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(value.to_lowercase())
+}
 
 #[derive(Deserialize, Serialize)]
 pub struct InternalHomeserverConfig {
+    #[serde(deserialize_with = "deserialize_lowercase")]
     pub server_name: String,
+    #[serde(deserialize_with = "deserialize_lowercase")]
     pub federation_domain: String,
+    #[serde(deserialize_with = "deserialize_lowercase")]
     pub target_base_url: String,
 }
 
 #[derive(Deserialize, Serialize)]
 pub struct ExternalHomeserverConfig {
+    #[serde(deserialize_with = "deserialize_lowercase")]
     pub server_name: String,
     // Should domains be fetched dynamically from well-known files?
     // A bit less secure, but more convenient?
+    #[serde(deserialize_with = "deserialize_lowercase")]
     pub federation_domain: String,
+    #[serde(deserialize_with = "deserialize_lowercase")]
     pub client_domain: String,
     pub verify_keys: BTreeMap<String, String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
+use url::Url;
 
 // Lowercase at import time the requested string.
 // This will enforce domains to be lowercase...
@@ -12,13 +13,23 @@ where
     Ok(value.to_ascii_lowercase())
 }
 
+// Special deserializer for base URLs, which will ensure that the URL is valid and normalized
+fn deserialize_base_url<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    let url = Url::parse(&value).map_err(de::Error::custom)?;
+    Ok(url.to_string())
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct InternalHomeserverConfig {
     #[serde(deserialize_with = "deserialize_lowercase")]
     pub server_name: String,
     #[serde(deserialize_with = "deserialize_lowercase")]
     pub federation_domain: String,
-    #[serde(deserialize_with = "deserialize_lowercase")]
+    #[serde(deserialize_with = "deserialize_base_url")]
     pub target_base_url: String,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ where
 {
     let value = String::deserialize(deserializer)?;
     let url = Url::parse(&value).map_err(de::Error::custom)?;
-    Ok(url.to_string())
+    Ok(url.as_str().trim_end_matches('/').to_owned())
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,10 @@ async fn start_services(
     let mut target_base_urls: BTreeMap<String, String> = BTreeMap::new();
 
     for hs in config.internal_homeservers {
+        debug!(
+            "Internal homeserver {} with federation domain {} and target base url {}",
+            hs.server_name, hs.federation_domain, hs.target_base_url
+        );
         domain_server_name_map.insert(hs.federation_domain.clone(), hs.server_name.clone());
         target_base_urls.insert(hs.federation_domain, hs.target_base_url.clone());
         // This is useful for well known endpoints
@@ -61,6 +65,10 @@ async fn start_services(
     let mut public_key_map: PublicKeyMap = BTreeMap::new();
 
     for hs in config.external_homeservers {
+        debug!(
+            "External homeserver {} with federation domain {} and client domain {}",
+            hs.server_name, hs.federation_domain, hs.client_domain
+        );
         domain_server_name_map.insert(hs.federation_domain.clone(), hs.server_name.clone());
         allowed_federation_domains.insert(hs.federation_domain, hs.server_name.clone());
         domain_server_name_map.insert(hs.client_domain.clone(), hs.server_name.clone());

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,69 @@
+use simple_border_gateway::config::BorderGatewayConfig;
+
+#[test]
+fn test_config_deserialization() {
+    let config_toml = r#"
+        [inbound_proxy]
+        listen_adress = "0.0.0.0:8000"
+        
+        [outbound_proxy]
+        listen_adress = "0.0.0.0:3128"
+
+        ca_priv_key = "ca.pem"
+        ca_cert = "ca.crt"
+        
+        allowed_non_matrix_regexes_dangerous = [
+            "https://ntfy\\.sh/.*"
+        ]
+        
+        [[internal_homeservers]]
+        server_name = "Tout.IM"
+        federation_domain = "Matrix.TOUT.im"
+        target_base_url = "http://localhost:8008"
+        
+        [[external_homeservers]]
+        server_name = "Matrix.org"
+        federation_domain = "matrix-federation.MATRIX.org"
+        client_domain = "matrix-CLient.MATRIX.org"
+        verify_keys = { "ed25519:a_RXGa" = "l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ" }
+    "#;
+
+    let config: BorderGatewayConfig = toml::from_str(config_toml).unwrap();
+
+    // Testing lowercasing for both internal and external homeservers
+    assert_eq!(config.internal_homeservers[0].server_name, "tout.im");
+    assert_eq!(
+        config.internal_homeservers[0].federation_domain,
+        "matrix.tout.im"
+    );
+    assert_eq!(
+        config.external_homeservers[0].federation_domain,
+        "matrix-federation.matrix.org"
+    );
+    assert_eq!(config.external_homeservers[0].server_name, "matrix.org");
+
+    // Checking if the verify_keys are correctly deserialized
+    assert_eq!(
+        *config.external_homeservers[0]
+            .verify_keys
+            .get("ed25519:a_RXGa")
+            .unwrap(),
+        "l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ".to_owned()
+    );
+
+    // Checking the listen addresses and the proxy configurations
+    let inbound = config.inbound_proxy.as_ref().unwrap();
+    let outbound = config.outbound_proxy.as_ref().unwrap();
+    assert_eq!(inbound.listen_address, "0.0.0.0:8000");
+    assert_eq!(outbound.listen_address, "0.0.0.0:3128");
+
+    // Checking CA configuration
+    assert_eq!(outbound.ca_cert, "ca.crt".to_owned());
+    assert_eq!(outbound.ca_priv_key, "ca.pem".to_owned());
+
+    // Checking the allowed non-matrix regexes
+    assert_eq!(
+        outbound.allowed_non_matrix_regexes_dangerous,
+        vec!["https://ntfy\\.sh/.*".to_owned()]
+    );
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -19,7 +19,7 @@ fn test_base_url_deserialization() {
         [[internal_homeservers]]
         server_name = "Tout.IM"
         federation_domain = "Matrix.TOUT.im"
-        target_base_url = "http://LOCALHOST:8008/chat/Test"
+        target_base_url = "http://LOCALHOST:8008/chat/Test/"
         
         [[external_homeservers]]
         server_name = "Matrix.org"
@@ -29,7 +29,7 @@ fn test_base_url_deserialization() {
     "#;
 
     let config: BorderGatewayConfig = toml::from_str(config_toml).unwrap();
-    // The base url is lowercased, but the path should be preserved as-is...
+    // The base url is lowercased, but the path should be preserved as-is, minus the final slash...
     assert_eq!(
         config.internal_homeservers[0].target_base_url,
         "http://localhost:8008/chat/Test"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,42 @@
 use simple_border_gateway::config::BorderGatewayConfig;
 
 #[test]
+fn test_base_url_deserialization() {
+    let config_toml = r#"
+        [inbound_proxy]
+        listen_adress = "0.0.0.0:8000"
+        
+        [outbound_proxy]
+        listen_adress = "0.0.0.0:3128"
+
+        ca_priv_key = "ca.pem"
+        ca_cert = "ca.crt"
+        
+        allowed_non_matrix_regexes_dangerous = [
+            "https://ntfy\\.sh/.*"
+        ]
+        
+        [[internal_homeservers]]
+        server_name = "Tout.IM"
+        federation_domain = "Matrix.TOUT.im"
+        target_base_url = "http://LOCALHOST:8008/chat/Test"
+        
+        [[external_homeservers]]
+        server_name = "Matrix.org"
+        federation_domain = "matrix-federation.MATRIX.org"
+        client_domain = "matrix-CLient.MATRIX.org"
+        verify_keys = { "ed25519:a_RXGa" = "l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ" }
+    "#;
+
+    let config: BorderGatewayConfig = toml::from_str(config_toml).unwrap();
+    // The base url is lowercased, but the path should be preserved as-is...
+    assert_eq!(
+        config.internal_homeservers[0].target_base_url,
+        "http://localhost:8008/chat/Test"
+    );
+}
+
+#[test]
 fn test_config_deserialization() {
     let config_toml = r#"
         [inbound_proxy]
@@ -48,7 +84,7 @@ fn test_config_deserialization() {
             .verify_keys
             .get("ed25519:a_RXGa")
             .unwrap(),
-        "l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ".to_owned()
+        "l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ"
     );
 
     // Checking the listen addresses and the proxy configurations
@@ -58,12 +94,12 @@ fn test_config_deserialization() {
     assert_eq!(outbound.listen_address, "0.0.0.0:3128");
 
     // Checking CA configuration
-    assert_eq!(outbound.ca_cert, "ca.crt".to_owned());
-    assert_eq!(outbound.ca_priv_key, "ca.pem".to_owned());
+    assert_eq!(outbound.ca_cert, "ca.crt");
+    assert_eq!(outbound.ca_priv_key, "ca.pem");
 
     // Checking the allowed non-matrix regexes
     assert_eq!(
         outbound.allowed_non_matrix_regexes_dangerous,
-        vec!["https://ntfy\\.sh/.*".to_owned()]
+        vec!["https://ntfy\\.sh/.*"]
     );
 }


### PR DESCRIPTION
Hello! 

This PR automatically lowercase all domains in both internal and external homeserver configuration paths. 
The lowercasing is happening at import/deserialization time to avoid issues and further conversions.